### PR TITLE
default to first project dir when no file is open

### DIFF
--- a/lib/run-in-terminal.coffee
+++ b/lib/run-in-terminal.coffee
@@ -43,7 +43,17 @@ git_directory = (file_dir) ->
 start_terminal = (terminal, exec_arg, command) =>
 
     file_path = atom.workspace.getActivePaneItem()?.buffer?.file?.path or ""
-    file_dir = path.dirname(file_path)
+
+    # if there is no file path then default to first project directory
+    if !file_path
+      proj_dirs = atom.project.getDirectories()
+      if proj_dirs.length
+        file_path = proj_dirs[0].path
+        file_dir = file_path
+
+    if !file_dir
+      file_dir = path.dirname(file_path)
+
     proj_dir = project_directory(file_dir)
     git_dir = git_directory(file_dir)
 


### PR DESCRIPTION
When there is no file open the terminal opens with a cwd of the tool/cmd being used.  It may make more sense to default to the first project dir.

I guess ideally there should be an option for this and when not checked show an error.

Please feel free to close if this functionality is not wanted/needed ;)
