### PR TITLE
Mac osx terminal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,8 @@ and «terminal execution argument»:
 
     /k
 
-#### Mac users may use «open» command with their favorite terminal app:
+#### Mac users do not have to select a terminal, as the standard terminal will always load.
 
-    open -a /path/to/terminal.app
-    
-Since terminal.app can't receive execution commands directly from command line, you must choose one:
-* install another terminal
-* run as «just run terminal without commands» (Terminal with argument: `open -a -n /Applications/Utilities/Terminal.app {working_directory}`).
-* run as «run this script by it shebang» (Terminal with argument: `open -a -n /Applications/Utilities/Terminal.app {file_path}`) and add mark script as executable (`chomd +x your-script.py`).
-
-For last two options you should use `start-terminal-here` action.
 
 ## Interpolation parameters
 | Parameter           | Description                       |
@@ -58,7 +50,7 @@ For last two options you should use `start-terminal-here` action.
 | {git_directory}     | path to nearest git root directory|
 
 ## How it works
-In deep, run-in-terminal use node.js child_process.exec function, so exec have cwd (current working directory) argument. But it doesn't works for any terminal. Some of them need launch «working directory» argument. That's why run-in-terminal have string interpolation of arguments. What is string interpolation means? run-in-terminal build full command at first step and replace predefined substrings with parameters at second. For values from «example value» column above we can have such scenario: opened /path/to/somedir/foo.py, which have #!/usr/bin/python3 shebang
+In deep, run-in-terminal uses the node.js child_process.exec function, so exec have cwd (current working directory) argument. But it doesn't works for all terminals. Some of them need launch «working directory» argument. That's why run-in-terminal have string interpolation of arguments. What does string interpolation mean? run-in-terminal builds full command at first step and replace predefined substrings with parameters at second. For values from «example value» column above we can have such scenario: opened /path/to/somedir/foo.py, which have #!/usr/bin/python3 shebang
 
     start-terminal-here-and-run -> konsole --noclose --workdir {working_directory} -e /usr/bin/python3 {file_path}
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # run-in-terminal package
 
-Atom package for run some commands in terminal, or just run terminal.
+Atom package for executing your current file directly in terminal, or just open the terminal with a specified directory.
 
 ## Why?
 Some packages can run terminal «here», some can run scripts not in terminal, but tabs/views/etc. I prefer terminal, so this one can run terminal «here» with any arguments and run scripts or any kind of shell «one-liners».
@@ -11,10 +11,16 @@ Some packages can run terminal «here», some can run scripts not in terminal, b
 * start terminal here and run some command with extra arguments
 * string interpolation with arguments
 * understanding shebang (utf-8 only)
-* launchers — file extension based command chooser
+* programs — file extension based program chooser
 * separate context menus for tabs, tree and editor
 
 ## What's new ([changelog](https://github.com/pohmelie/run-in-terminal/blob/master/CHANGELOG.md))
+#### 0.6.1 - Improved OS X support
+* feature: OS X users can now run any file directly in the terminal, based on configurable Applescript command.
+* feature: Default settings added for OS X and Windows users.
+* note: Not backward compatible with previous versions, please update your settings.
+* note: Autoquotation removed from the settings menu, as quotes can now be directly edited in the commands.
+
 #### 0.6.0 - run with arguments
 * feature: start terminal and run with extra arguments
 
@@ -22,43 +28,37 @@ Some packages can run terminal «here», some can run scripts not in terminal, b
 
 | Field                          |   Type  |                Description                               |        Default value             |                 Example value                   |
 |:------------------------------:|:-------:|:--------------------------------------------------------:|:--------------------------------:|:-----------------------------------------------:|
-| Terminal                       | string  | command to start terminal with argumenst                 | your-favorite-terminal arguments | konsole --noclose --workdir {working_directory} |
-| Terminal execution argument    | string  | argument to run some command in terminal                 | terminal-execution-argument      | -e                                              |
-| List of launchers by extension | string  | comma separated pairs: extension-launcher                | your-launchers                   | .py python3 {file_path}, .lua lua {file_path}   |
-| Save file before run terminal  | boolean |                                                          | true                             | true                                            |
-| Use exec cwd                   | boolean | child_process.exec cwd parameter                         | true                             | true                                            |
-| Use shebang                    | boolean | use shebang if available                                 | true                             | true                                            |
-| Autoquotation                  | boolean | adding double quotation mark to interpolation parameters | true                             | true                                            |
-
-#### Windows users may use «start» command with «cmd»:
-
-    start /D {working_directory} C:\Windows\System32\cmd.exe /u
-
-and «terminal execution argument»:
-
-    /k
-
-#### Mac users do not have to select a terminal, as the standard terminal will always load.
+| Launch file in terminal command| string  | command to start the terminal and run a program based on filetype or shebang       | operating system dependent       | konsole --noclose --workdir "{working_directory}" -e {launcher} "{file_dir}" |
+| Save file before run terminal  | boolean | Saves the open file before the terminal is started       | true                             | -                                               |
+| Launch directory in terminal command   | string  | command to start the terminal and open a directory   | operating system dependent   | konsole --noclose --workdir "{working_directory}" |
+| List of programs by extension  | string  | comma separated pairs: extension-program                 | your-programs                    | .py python3, .lua lua                           |
+| Use exec cwd                   | boolean | child_process.exec cwd parameter                         | true                             | -                                               |
+| Use shebang                    | boolean | use shebang if available                                 | true                             | -                                               |
 
 
 ## Interpolation parameters
 | Parameter           | Description                       |
 |:-------------------:|:---------------------------------:|
 | {file_path}         | path to current file              |
+| {launcher}          | selected program from list or shebang|
+| {args}              | additional (optional) arguments   |
 | {working_directory} | path to current working directory |
 | {project_directory} | path to project's root directory  |
 | {git_directory}     | path to nearest git root directory|
 
-## How it works
-In deep, run-in-terminal uses the node.js child_process.exec function, so exec have cwd (current working directory) argument. But it doesn't work for all terminals. Some of them need launch «working directory» argument. That's why run-in-terminal have string interpolation of arguments. What does string interpolation mean? run-in-terminal builds full command at first step and replace predefined substrings with parameters at second. For values from «example value» column above we can have such scenario: opened /path/to/somedir/foo.py, which have #!/usr/bin/python3 shebang
 
-    start-terminal-here-and-run -> konsole --noclose --workdir {working_directory} -e /usr/bin/python3 {file_path}
+## How it works
+In deep, run-in-terminal uses the node.js child_process.exec function, so exec have cwd (current working directory) argument. But it doesn't work for all terminals. Some of them need the launch «working directory» argument. That's why run-in-terminal have string interpolation of arguments. What does string interpolation mean? run-in-terminal builds full command at first step and replace predefined substrings with parameters at second. For values from «example value» column above we can have such scenario:
+
+Current opened file in Atom: /path/to/somedir/foo.py, which has #!/usr/bin/python3 as shebang.
+
+    start-terminal-here-and-run -> konsole --noclose --workdir "{working_directory}" -e /usr/bin/python3 "{file_path}"
 
 this will be interpolated to:
 
     start-terminal-here-and-run -> konsole --noclose --workdir "/path/to/somedir" -e /usr/bin/python3 "/path/to/somedir/foo.py"
 
-If run-in-terminal can't determine launcher or file_path (file not saved and have no name) it will do start-terminal-here.
+If run-in-terminal can't determine launcher or file_path (file not saved and has no name) it will do start-terminal-here.
 
 ## Thanks to:
-[bobrocke](https://github.com/bobrocke), [clintwood](https://github.com/clintwood), [LeoVerto](https://github.com/LeoVerto), [marales](https://github.com/marales), [djengineerllc](https://github.com/djengineerllc), [LevPasha](https://github.com/LevPasha), [Kee-Wang](https://github.com/Kee-Wang).
+[bobrocke](https://github.com/bobrocke), [clintwood](https://github.com/clintwood), [LeoVerto](https://github.com/LeoVerto), [marales](https://github.com/marales), [djengineerllc](https://github.com/djengineerllc), [LevPasha](https://github.com/LevPasha), [Kee-Wang](https://github.com/Kee-Wang), [jnelissen](https://github.com/jnelissen).

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ and «terminal execution argument»:
 | {git_directory}     | path to nearest git root directory|
 
 ## How it works
-In deep, run-in-terminal uses the node.js child_process.exec function, so exec have cwd (current working directory) argument. But it doesn't works for all terminals. Some of them need launch «working directory» argument. That's why run-in-terminal have string interpolation of arguments. What does string interpolation mean? run-in-terminal builds full command at first step and replace predefined substrings with parameters at second. For values from «example value» column above we can have such scenario: opened /path/to/somedir/foo.py, which have #!/usr/bin/python3 shebang
+In deep, run-in-terminal uses the node.js child_process.exec function, so exec have cwd (current working directory) argument. But it doesn't work for all terminals. Some of them need launch «working directory» argument. That's why run-in-terminal have string interpolation of arguments. What does string interpolation mean? run-in-terminal builds full command at first step and replace predefined substrings with parameters at second. For values from «example value» column above we can have such scenario: opened /path/to/somedir/foo.py, which have #!/usr/bin/python3 shebang
 
     start-terminal-here-and-run -> konsole --noclose --workdir {working_directory} -e /usr/bin/python3 {file_path}
 

--- a/lib/run-in-terminal.coffee
+++ b/lib/run-in-terminal.coffee
@@ -100,7 +100,7 @@ start_terminal = (start_path, args) =>
 
         if shebang
 
-            cmd.push(read_option("terminal_exec_arg")) if read_option("terminal_exec_arg") != "terminal-execution-argument"
+            cmd.push(read_option("terminal_exec_arg"))
             cmd.push(shebang)
             cmd.push("{file_path}")
             if os.platform() == "darwin"
@@ -108,7 +108,7 @@ start_terminal = (start_path, args) =>
 
         else if current_launcher
 
-            cmd.push(read_option("terminal_exec_arg")) if read_option("terminal_exec_arg") != "terminal-execution-argument"
+            cmd.push(read_option("terminal_exec_arg"))
             cmd.push(current_launcher)
             if os.platform() == "darwin"
               cmd.push(cmd_mac_end)
@@ -243,7 +243,17 @@ class ArgumentsRequester
                 @save_and_hide()
                 start_terminal(@path or "", @line_edit_model.getText())
 
-
+switch require('os').platform()
+  when 'darwin'
+    defaultTerminal = ''
+    defaultTerminal_exec_arg = ''
+  when 'win32'
+    defaultTerminal = 'start /D {working_directory} C:\Windows\System32\cmd.exe /u'
+    defaultTerminal_exec_arg = '/k'
+  else
+    defaultTerminal = 'your-favorite-terminal --foo --bar'
+    defaultTerminal_exec_arg = 'terminal-execution-argument'
+    
 module.exports =
 
     activate: (state) ->
@@ -409,14 +419,14 @@ module.exports =
 
             title: "Terminal with arguments (Leave blank for Mac OS X)"
             type: "string"
-            default: "your-favorite-terminal --foo --bar"
+            default: defaultTerminal
 
         terminal_exec_arg:
 
             title: "Terminal execution argument"
             description: "This is the last flag for executing command directly in terminal (see the readme for more information)"
             type: "string"
-            default: "terminal-execution-argument"
+            default: defaultTerminal_exec_arg
 
         launchers:
 

--- a/lib/run-in-terminal.coffee
+++ b/lib/run-in-terminal.coffee
@@ -113,7 +113,6 @@ start_terminal = (start_path, args) =>
             if os.platform() == "darwin"
               cmd.push(cmd_mac_end)
 
-        # if os.platform() != "darwin"
         cmd.push(args) if args
 
     else if stats.isDirectory()

--- a/lib/run-in-terminal.coffee
+++ b/lib/run-in-terminal.coffee
@@ -372,11 +372,11 @@ module.exports =
             start_path = path.dirname(start_path) if not should_run
             if request_arguments
 
-                    @arguments_view.show(start_path)
+                @arguments_view.show(start_path)
 
-                else
+            else
 
-                    start_terminal(start_path)
+                start_terminal(start_path)
 
     config:
 

--- a/lib/run-in-terminal.coffee
+++ b/lib/run-in-terminal.coffee
@@ -198,7 +198,7 @@ class ArgumentsRequester
 
         })
 
-        @line_edit_view.addEventListener("focusout", @save_and_hide)
+        @line_edit_view.addEventListener("blur", @save_and_hide)
         @line_edit_view.addEventListener("keydown", @key_pressed)
 
         @attributes_memory = {}
@@ -238,16 +238,16 @@ class ArgumentsRequester
 switch require('os').platform()
 
     when 'darwin'
-        default_Launchfile = """osascript -e 'tell application \"Terminal\"' -e 'activate' -e 'tell application \"Terminal\" to do script \"cd \\\"{working_directory}\\\" && {launcher} \\\"{file_path}\\\" \"' -e 'end tell'"""
-        default_Launchdir = """osascript -e 'tell application \"Terminal\"' -e 'activate' -e 'tell application \"Terminal\" to do script \"cd \\\"{working_directory}\\\" \"' -e 'end tell'"""
+        default_launchfile = """osascript -e 'tell application \"Terminal\"' -e 'activate' -e 'tell application \"Terminal\" to do script \"cd \\\"{working_directory}\\\" && {launcher} \\\"{file_path}\\\" \"' -e 'end tell'"""
+        default_launchdir = """osascript -e 'tell application \"Terminal\"' -e 'activate' -e 'tell application \"Terminal\" to do script \"cd \\\"{working_directory}\\\" \"' -e 'end tell'"""
 
     when 'win32'
-        default_Launchfile = 'start /D {working_directory} C:\Windows\System32\cmd.exe /u /k cd "{working_directory}" {launcher} "{file_path}"'
-        default_Launchdir = 'start /D {working_directory} C:\Windows\System32\cmd.exe /u /k cd "{working_directory}"'
+        default_launchfile = 'start /D {working_directory} C:\\Windows\\System32\\cmd.exe /u /k {launcher} "{file_path}"'
+        default_launchdir = 'start /D {working_directory} C:\\Windows\\System32\\cmd.exe /u /k'
 
     else
-        default_Launchfile = 'your-favorite-terminal --foo --bar "{working_directory}" {launcher} "{file_path}"'
-        default_Launchdir = 'your-favorite-terminal --foo --bar "{working_directory}"'
+        default_launchfile = 'your-favorite-terminal --foo --bar "{working_directory}" {launcher} "{file_path}"'
+        default_launchdir = 'your-favorite-terminal --foo --bar "{working_directory}"'
 
 module.exports =
 
@@ -414,7 +414,7 @@ module.exports =
             description: "Enter the command to open and run a file in the terminal"
             type: "string"
             order: 1
-            default: default_Launchfile
+            default: default_launchfile
 
         launchdir:
 
@@ -422,7 +422,7 @@ module.exports =
             description: "Enter the command to open the terminal in the defined directory"
             type: "string"
             order: 3
-            default: default_Launchdir
+            default: default_launchdir
 
         launchers:
 

--- a/lib/run-in-terminal.coffee
+++ b/lib/run-in-terminal.coffee
@@ -7,7 +7,7 @@ os = require("os")
 interpolate = (s, o) ->
 
     choose = (a, b) -> if typeof(o[b]) in ["string", "number"] then o[b] else a
-    s.replace(/{([^{}]*)}/g, (a, b) -> choose(a, b))
+    s.replace(/{([^{}]*)}/g, choose)
 
 
 strip = (s) ->
@@ -87,32 +87,32 @@ start_terminal = (start_path, args) =>
 
             shebang = read_shebang(file_path)
 
-        for pair in read_option("programs").split(",").map(strip)
+        for pair in read_option("launchers").split(",").map(strip)
 
-            [end, program...] = pair.split(" ").map(strip)
+            [end, launcher...] = pair.split(" ").map(strip)
             if file_path.indexOf(end, file_path.length - end.length) != -1
 
-                current_program = program.join(" ")
+                current_launcher = launcher.join(" ")
                 break
 
         if shebang
 
-          parameters.launcher = shebang
+            parameters.launcher = shebang
 
-        else if current_program
+        else if current_launcher
 
-          parameters.launcher = current_program
+            parameters.launcher = current_launcher
 
         else
 
-          atom.notifications.addError('Run-in-terminal: No program found in "List of programs" for current filetype or shebang not found')
+            atom.notifications.addError('Run-in-terminal: No program found in "List of programs" for current filetype or shebang not found')
 
         parameters.args = args
 
     else if stats.isDirectory()
 
-      cmd = read_option("launchdir")
-      parameters.working_directory = start_path
+        cmd = read_option("launchdir")
+        parameters.working_directory = start_path
 
     else
 
@@ -135,7 +135,6 @@ start_terminal = (start_path, args) =>
 
     cmd_line = interpolate(cmd, parameters)
     child_process.exec(cmd_line, cwd: exec_cwd, (error, stdout, stderr) ->
-
 
         if error
 
@@ -199,8 +198,7 @@ class ArgumentsRequester
 
         })
 
-        # Request args does not work if below line is uncommented? (OS X)
-        # @line_edit_view.addEventListener("focusout", @save_and_hide)
+        @line_edit_view.addEventListener("focusout", @save_and_hide)
         @line_edit_view.addEventListener("keydown", @key_pressed)
 
         @attributes_memory = {}
@@ -238,15 +236,18 @@ class ArgumentsRequester
                 start_terminal(@path or "", @line_edit_model.getText())
 
 switch require('os').platform()
-  when 'darwin'
-    defaultLaunchfile = """osascript -e 'tell application \"Terminal\"' -e 'activate' -e 'tell application \"Terminal\" to do script \"cd \\\"{working_directory}\\\" && {launcher} \\\"{file_path}\\\" \"' -e 'end tell'"""
-    defaultLaunchdir = """osascript -e 'tell application \"Terminal\"' -e 'activate' -e 'tell application \"Terminal\" to do script \"cd \\\"{working_directory}\\\" \"' -e 'end tell'"""
-  when 'win32'
-    defaultLaunchfile = 'start /D {working_directory} C:\Windows\System32\cmd.exe /u /k cd "{working_directory}" & {launcher} "{file_path}"'
-    defaultLaunchdir = 'start /D {working_directory} C:\Windows\System32\cmd.exe /u /k cd "{working_directory}"'
-  else
-    defaultLaunchfile = 'your-favorite-terminal --foo --bar "{working_directory}" && {launcher} "{file_path}"'
-    defaultLaunchdir = 'your-favorite-terminal --foo --bar "{working_directory}"'
+
+    when 'darwin'
+        default_Launchfile = """osascript -e 'tell application \"Terminal\"' -e 'activate' -e 'tell application \"Terminal\" to do script \"cd \\\"{working_directory}\\\" && {launcher} \\\"{file_path}\\\" \"' -e 'end tell'"""
+        default_Launchdir = """osascript -e 'tell application \"Terminal\"' -e 'activate' -e 'tell application \"Terminal\" to do script \"cd \\\"{working_directory}\\\" \"' -e 'end tell'"""
+
+    when 'win32'
+        default_Launchfile = 'start /D {working_directory} C:\Windows\System32\cmd.exe /u /k cd "{working_directory}" {launcher} "{file_path}"'
+        default_Launchdir = 'start /D {working_directory} C:\Windows\System32\cmd.exe /u /k cd "{working_directory}"'
+
+    else
+        default_Launchfile = 'your-favorite-terminal --foo --bar "{working_directory}" {launcher} "{file_path}"'
+        default_Launchdir = 'your-favorite-terminal --foo --bar "{working_directory}"'
 
 module.exports =
 
@@ -370,9 +371,12 @@ module.exports =
 
             start_path = path.dirname(start_path) if not should_run
             if request_arguments
-              @arguments_view.show(start_path)
-            else
-              start_terminal(start_path)
+
+                    @arguments_view.show(start_path)
+
+                else
+
+                    start_terminal(start_path)
 
     config:
 
@@ -410,7 +414,7 @@ module.exports =
             description: "Enter the command to open and run a file in the terminal"
             type: "string"
             order: 1
-            default: defaultLaunchfile
+            default: default_Launchfile
 
         launchdir:
 
@@ -418,9 +422,9 @@ module.exports =
             description: "Enter the command to open the terminal in the defined directory"
             type: "string"
             order: 3
-            default: defaultLaunchdir
+            default: default_Launchdir
 
-        programs:
+        launchers:
 
             title: "List of programs by extension"
             description: "See the readme for more information"

--- a/lib/run-in-terminal.coffee
+++ b/lib/run-in-terminal.coffee
@@ -102,7 +102,7 @@ start_terminal = (start_path, args) =>
 
             cmd.push(read_option("terminal_exec_arg")) if read_option("terminal_exec_arg") != "terminal-execution-argument"
             cmd.push(shebang)
-            cmd.push(file_path)
+            cmd.push("{file_path}")
             if os.platform() == "darwin"
               cmd.push(cmd_mac_end)
 
@@ -118,7 +118,7 @@ start_terminal = (start_path, args) =>
     else if stats.isDirectory()
         if os.platform() == "darwin"
           cmd = ["""osascript -e 'tell application \"Terminal\"' -e 'activate' -e 'tell application \"Terminal\" to do script "cd"""]
-          cmd.push(start_path)
+          cmd.push("{working_directory}")
           cmd.push(cmd_mac_end)
         parameters.working_directory = start_path
 
@@ -407,7 +407,7 @@ module.exports =
 
         terminal:
 
-            title: "Terminal with arguments"
+            title: "Terminal with arguments (Leave blank for Mac OS X)"
             type: "string"
             default: "your-favorite-terminal --foo --bar"
 


### PR DESCRIPTION
I have added support for the standard Mac OSX terminal. Currently run-in-terminal is able to open the terminal, but not run the code at the same time as well. The workaround to chmod +x the file and add a shebang to the file works, but this is not the intention setup of the program.

The code now checks if the operating system is osx (darwin), and sets up the correct Applescript command to open the terminal and run the code, or open the terminal at the working directory. This only works with the standard terminal in OSX, other terminal apps like iTerm are not supported.

Adding terminal arguments for Mac is not possible. You can however write command commands in the argument (separated by semicolons) field, which will be executed before the script, e.g. "cd /some/dir;". This is not something I added by the way, I just found out when adding arguments for testing. 

Most changes to the code are only executed if you're on OSX. The standard code has been left intact and should cause no problems. I did notice however that autoquotation of file paths was not working when shebang was activated. I made a small change to the existing code in case shebang was used. There might be another way of adding the quotes here, for me this works ok. Now filenames with spaces are always loaded correctly.

I have also updated the README.md file for Mac, and corrected some general typos.

As this is my first contribution to Github I hope I did everything ok, please let me know if you have any comments or need more information. Great package by the way! 👍 